### PR TITLE
save the patch with uint8, decrease the memory

### DIFF
--- a/generate_patches.py
+++ b/generate_patches.py
@@ -81,7 +81,7 @@ def generate_patches(isDebug=False):
         inputs[-to_pad:, :, :, :] = inputs[:to_pad, :, :, :]
     
     assert np.max(inputs) > 1
-    inputs = inputs / 255.0  # normalize to [0, 1]
+    #inputs = inputs / 255.0  # normalize to [0, 1]
     
     if not os.path.exists(args.save_dir):
         os.mkdir(args.save_dir)

--- a/generate_patches.py
+++ b/generate_patches.py
@@ -81,7 +81,7 @@ def generate_patches(isDebug=False):
         inputs[-to_pad:, :, :, :] = inputs[:to_pad, :, :, :]
     
     assert np.max(inputs) > 1
-    #inputs = inputs / 255.0  # normalize to [0, 1]
+    # inputs = inputs / 255.0  # normalize to [0, 1]
     
     if not os.path.exists(args.save_dir):
         os.mkdir(args.save_dir)

--- a/model.py
+++ b/model.py
@@ -136,6 +136,7 @@ class DnCNN(object):
         for epoch in xrange(self.epoch):
             for batch_id in xrange(numBatch):
                 batch_images = data[batch_id * self.batch_size:(batch_id + 1) * self.batch_size, :, :, :]
+                batch_images = np.array(batch_images / 255.0, dtype=np.float32)
                 train_images = add_noise(batch_images, self.sigma, self.sess)
                 _, loss, summary = self.sess.run([self.train_step, self.loss, merged], \
                                                  feed_dict={self.X: train_images, self.X_: batch_images})


### PR DESCRIPTION
Hi, thanks for your work . I notice that you save the patch data with np.float64, and it need about 12GB memory to save this. I change the code , save with np.uint8, and normolize the batch data when training. 